### PR TITLE
Fix: Ensure installer closes properly by stopping music playback

### DIFF
--- a/setupmaker.iss
+++ b/setupmaker.iss
@@ -262,3 +262,23 @@ begin
   end;
   Log('InitializeWizard finished.');
 end;
+
+procedure DeinitializeSetup();
+var
+  StopResult: Boolean;
+begin
+  Log('DeinitializeSetup called.');
+  if MusicPlaying then
+  begin
+    Log('Attempting to stop music playback...');
+    StopResult := DSStopMediaPlay;
+    if StopResult then
+      Log('DSStopMediaPlay successful.')
+    else
+      Log('DSStopMediaPlay FAILED.');
+  end
+  else
+  begin
+    Log('Music is not playing, no need to stop.');
+  end;
+end;


### PR DESCRIPTION
Added DeinitializeSetup function to stop music playback when the installer exits. This should resolve the issue where the installer was not closing entirely after installation.